### PR TITLE
Add patchset and xplugeth build tags where necessary

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -33,7 +33,7 @@ def getPatches(cmd):
     try:
         with open("get_patchset.go", "w") as fd:
             fd.write(patchset_go)
-        x = json.loads(go.run("get_patchset.go", "xplugeth_imports.go"))
+        x = json.loads(go.run("-tags=patchset xplugeth", "get_patchset.go", "xplugeth_imports.go"))
         os.remove("get_patchset.go")
         return x
     finally:
@@ -84,7 +84,7 @@ def main(remote, tag, plugins, cmd, artifacts_directory, workdir):
         git.clean("-fdx")
         git.checkout(tag)
         with open(os.path.join(cmd, "xplugeth_imports.go"), "w") as fd:
-            fd.write("package main\nimport (\n")
+            fd.write("//go:build xplugeth\npackage main\nimport (\n")
             for plugin in plugins:
                 print(go.get(plugin))
                 fd.write('\t_ "%s"\n' % (plugin.split("@")[0]))
@@ -98,7 +98,7 @@ def main(remote, tag, plugins, cmd, artifacts_directory, workdir):
 
         apply_patches(getPatches(cmd))
 
-        print(go.build("-o", os.path.join(artifacts_directory, os.path.split(cmd)[-1]), cmd))
+        print(go.build("-tags=xplugeth", "-o", os.path.join(artifacts_directory, os.path.split(cmd)[-1]), cmd))
     finally:
         os.chdir(orig)
 

--- a/plugins/producer/triedump.go
+++ b/plugins/producer/triedump.go
@@ -1,4 +1,6 @@
+//go:build !patchset
 package producer
+
 
 import (
 	"fmt"

--- a/plugins/producer/triedump_patchset.go
+++ b/plugins/producer/triedump_patchset.go
@@ -1,0 +1,15 @@
+//go:build patchset
+package producer
+
+import (
+	cli "github.com/urfave/cli/v2"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func stateTrieUpdatesByNumber(i int64) (map[common.Hash]struct{}, map[common.Hash][]byte, map[common.Hash]map[common.Hash][]byte, map[common.Hash][]byte, error) {
+	return nil, nil, nil, nil, nil
+}
+
+func trieDump (ctx cli.Context, args []string) error {
+	return nil
+}


### PR DESCRIPTION
The producer plugin relies on StateDB.GetTrie() being present. It's available in Foundation Geth, and we patch it in for ETC and Bor with patchsets, but we need to be able to compile get_patchset.go for that to work. Compiling get_patchset.go fails because StateDB.GetTrie() doesn't exist until after we've patched, which we can't do until we've compiled get_patchset.go.

To solve this chicken or egg problem, we introduce a patchset build tag, which we pass in only when building get_patchset.go. The producer plugin has an alternate version of triedump.go that provides stubs that don't rely on patched interfaces.

We'll need to establish (and document) this as a pattern for plugins that rely on those kinds of extensions, that those extensions will need to be implemented in files that aren't included with the patchset flag.

Further, when xplugeth_imports.go was in the cmd/geth directory and tests were run, the producer plugin was incorporated into tests. If the state hooks were patched in before the init hooks the tests passed. If The init hooks got patched first, the tests would fail because of the producer plugin's dependency on the state hooks.

To solve this, we add an xplugeth build tag to the xplugeth_imports.go as we build it, and add that build tag during the final build. This keeps xplugeth_imports.go from being included during tests, so it doesn't interfere with the init patchsets.